### PR TITLE
archive.is -> archive.today

### DIFF
--- a/Network/URL/Archiver.hs
+++ b/Network/URL/Archiver.hs
@@ -18,7 +18,7 @@ pingURL = void . simpleHTTP . getRequest
 checkArchive :: String -- ^ email for WebCite to send status to
                 -> String -- ^ URL to archive
                 -> IO ()
-checkArchive email url = when (isURI url) (alexaToolbar url >> webciteArchive email url >> internetArchiveLive url >> wikiwixArchive url >> googleSearch url >> archiveisArchive url)
+checkArchive email url = when (isURI url) (alexaToolbar url >> webciteArchive email url >> internetArchiveLive url >> wikiwixArchive url >> googleSearch url >> archivetodayArchive url)
 
 {- | Request <http://www.webcitation.org> to copy a supplied URL; WebCite does on-demand archiving, unlike Alexa/Internet Archive,
    and so in practice this is the most useful function. This function throws away any return status from WebCite (which may be changed
@@ -52,9 +52,9 @@ wikiwixArchive :: String -> IO ()
 wikiwixArchive url = pingURL ("http://archive.wikiwix.com/cache/?url="++url)
 
 -- | <http://blog.archive.is/post/45031162768/can-you-recommend-the-best-method-script-so-i-may-batch>
-archiveisArchive :: String -> IO ()
-archiveisArchive url = do let archiveform = Form POST (fromJust $ parseURI "http://archive.is/submit/") [("url", url), ("submit", "")]
-                          void $ browse $ request $ formToRequest archiveform
+archivetodayArchive :: String -> IO ()
+archivetodayArchive url = do let archiveform = Form POST (fromJust $ parseURI "http://archive.today/submit/") [("url", url), ("submit", "")]
+                             void $ browse $ request $ formToRequest archiveform
 
 -- can't hurt to let Google know it exists
 googleSearch :: String -> IO ()


### PR DESCRIPTION
http://blog.archive.today/post/82775187091/curious-why-the-move-in-domain-names-from-archive-is

Saves a redirect.
